### PR TITLE
add Wordpress data store

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ use League\OAuth2\Client\Provider\GenericProvider as OAuth2Provider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use jonathanraftery\Bullhorn\Rest\authentication\Exception\InvalidRefreshTokenException;
 use jonathanraftery\Bullhorn\JsonDataStore;
+use jonathanraftery\Bullhorn\WordpressDataStore;
 
 class Client
 {
@@ -18,10 +19,10 @@ class Client
     private $authProvider;
     private $dataStore;
 
-    public function __construct($clientId, $clientSecret, $dataStore = null)
+    public function __construct($clientId, $clientSecret, $dataStoreType = "json")
     { 
         $this->clientId = $clientId;
-        $this->dataStore = $dataStore ? $dataStore : new JsonDataStore();
+        $this->dataStore = ($dataStoreType == "wp") ? new WordpressDataStore() : new JsonDataStore();
         $this->authProvider = new OAuth2Provider([
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,7 +7,6 @@ use League\OAuth2\Client\Provider\GenericProvider as OAuth2Provider;
 use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use jonathanraftery\Bullhorn\Rest\authentication\Exception\InvalidRefreshTokenException;
 use jonathanraftery\Bullhorn\JsonDataStore;
-use jonathanraftery\Bullhorn\WordpressDataStore;
 
 class Client
 {
@@ -19,10 +18,10 @@ class Client
     private $authProvider;
     private $dataStore;
 
-    public function __construct($clientId, $clientSecret, $dataStoreType = "json")
+    public function __construct($clientId, $clientSecret, $dataStore = null)
     { 
         $this->clientId = $clientId;
-        $this->dataStore = ($dataStoreType == "wp") ? new WordpressDataStore() : new JsonDataStore();
+        $this->dataStore = $dataStore  ? $dataStore : new JsonDataStore();
         $this->authProvider = new OAuth2Provider([
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,

--- a/src/WordpressDataStore.php
+++ b/src/WordpressDataStore.php
@@ -1,0 +1,37 @@
+<?php
+	
+namespace jonathanraftery\Bullhorn;
+
+class WordpressDataStore implements DataStore
+{	
+    public function store($key, $value)
+    {
+        $data = $this->readDataFile();
+        $data->tokens->$key = $value;
+        $this->saveData($data);
+    }
+
+    public function get($key)
+    {
+        $data = $this->readDataFile();
+        if (isset($data->tokens->$key))
+            return $data->tokens->$key;
+        else
+            return null;
+    }
+
+    private function readDataFile()
+    {
+	    $data = get_transient("bullhorn-datastore");
+	    
+        if ($data)
+            return json_decode($data);
+        else
+            return json_decode('{"tokens":{}}');
+    }
+
+    private function saveData($newData)
+    {
+        set_transient("bullhorn-datastore", json_encode($newData), HOUR_IN_SECONDS);
+    }
+}


### PR DESCRIPTION
I wasn't sure how you wanted to handle choosing a data store, so I changed the the third parameter in the main Client class constructor to choose json or wp (with a default of json). This kills the option for a user to use their own created datastore but it still made sense to me so you don't have to create another object from the JsonDataStore or WordpressDataStore class. I may not be thinking about the easy way to do that, so feel free to edit if you'd like to combine the best of both worlds.