### PR TITLE
Change URL constant references from self to static

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,8 +28,8 @@ class Client
         $this->authProvider = new OAuth2Provider([
             'clientId' => $clientId,
             'clientSecret' => $clientSecret,
-            'urlAuthorize' => self::AUTH_URL,
-            'urlAccessToken' => self::TOKEN_URL,
+            'urlAuthorize' => static::AUTH_URL,
+            'urlAccessToken' => static::TOKEN_URL,
             'urlResourceOwnerDetails' => ''
         ]);
     }
@@ -128,7 +128,7 @@ class Client
         );
         $options['access_token'] = $accessToken;
 
-        $fullUrl = self::LOGIN_URL
+        $fullUrl = static::LOGIN_URL
             . '?' . http_build_query($options);
         $loginRequest = $this->authProvider->getAuthenticatedRequest(
             'GET',


### PR DESCRIPTION
This makes it possible to override the URLs for development purposes. In my use case I have a mock API that uses a different URL.

Overriding constants is not very pretty. A cleaner solution would be to follow SOLID more strictly, mainly the Open/closed and Dependency inversion principles. But as I have limited time this will do fine for me.

Thanks for the package!